### PR TITLE
Add Docker support for FastAPI example

### DIFF
--- a/06-fastapi-scrud/.dockerignore
+++ b/06-fastapi-scrud/.dockerignore
@@ -1,0 +1,2 @@
+__pycache__
+cuisines.db

--- a/06-fastapi-scrud/Dockerfile
+++ b/06-fastapi-scrud/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/06-fastapi-scrud/README.md
+++ b/06-fastapi-scrud/README.md
@@ -1,0 +1,51 @@
+# FastAPI CRUD example with SQLite
+
+This small example demonstrates how to build a FastAPI application that stores
+"cuisine" objects in a local SQLite database. Each cuisine has a name, a cooking
+time in minutes and a JSON document containing the ingredients.
+
+## Running locally
+
+You need Python 3.8+ with `fastapi`, `uvicorn` and `sqlalchemy` installed:
+
+```bash
+pip install fastapi uvicorn sqlalchemy
+```
+
+Start the application with:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The API will be available on `http://localhost:8000`. FastAPI automatically
+provides an interactive documentation under `/docs`.
+
+## Available endpoints
+
+- `POST /cuisines/` - create a new cuisine entry
+- `GET /cuisines/` - list cuisines
+- `GET /cuisines/{id}` - read a specific cuisine
+- `PUT /cuisines/{id}` - update a cuisine
+- `DELETE /cuisines/{id}` - remove a cuisine
+
+The database is stored in the file `cuisines.db` inside this directory. The
+schema is created automatically on startup.
+
+## Running with Docker
+
+You can also build a container image for this API. The repository contains a
+`Dockerfile` that installs the dependencies and launches `uvicorn`. Build and
+run the image:
+
+```bash
+docker build -t fastapi-scrud .
+docker run -p 8000:8000 fastapi-scrud
+```
+
+If you want to persist the SQLite database, mount the current directory as a
+volume:
+
+```bash
+docker run -p 8000:8000 -v $(pwd):/app fastapi-scrud
+```

--- a/06-fastapi-scrud/app/main.py
+++ b/06-fastapi-scrud/app/main.py
@@ -1,0 +1,80 @@
+from fastapi import FastAPI, HTTPException, Depends
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+from typing import List
+
+from .models import Base, Cuisine, CuisineCreate, CuisineUpdate, CuisineRead
+
+DATABASE_URL = "sqlite:///./cuisines.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+app = FastAPI()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.on_event("startup")
+def on_startup():
+    Base.metadata.create_all(bind=engine)
+
+
+@app.post("/cuisines/", response_model=CuisineRead)
+def create_cuisine(cuisine: CuisineCreate, db: Session = Depends(get_db)):
+    db_cuisine = Cuisine(**cuisine.dict())
+    db.add(db_cuisine)
+    db.commit()
+    db.refresh(db_cuisine)
+    return db_cuisine
+
+
+@app.get("/cuisines/", response_model=List[CuisineRead])
+def read_cuisines(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    cuisines = db.query(Cuisine).offset(skip).limit(limit).all()
+    return cuisines
+
+
+@app.get("/cuisines/{cuisine_id}", response_model=CuisineRead)
+def read_cuisine(cuisine_id: int, db: Session = Depends(get_db)):
+    cuisine = db.query(Cuisine).filter(Cuisine.id == cuisine_id).first()
+    if cuisine is None:
+        raise HTTPException(status_code=404, detail="Cuisine not found")
+    return cuisine
+
+
+@app.put("/cuisines/{cuisine_id}", response_model=CuisineRead)
+def update_cuisine(
+    cuisine_id: int,
+    cuisine: CuisineUpdate,
+    db: Session = Depends(get_db),
+):
+    db_cuisine = db.query(Cuisine).filter(Cuisine.id == cuisine_id).first()
+    if db_cuisine is None:
+        raise HTTPException(status_code=404, detail="Cuisine not found")
+
+    update_data = cuisine.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_cuisine, key, value)
+    db.commit()
+    db.refresh(db_cuisine)
+    return db_cuisine
+
+
+@app.delete("/cuisines/{cuisine_id}")
+def delete_cuisine(cuisine_id: int, db: Session = Depends(get_db)):
+    db_cuisine = db.query(Cuisine).filter(Cuisine.id == cuisine_id).first()
+    if db_cuisine is None:
+        raise HTTPException(status_code=404, detail="Cuisine not found")
+    db.delete(db_cuisine)
+    db.commit()
+    return {"ok": True}
+

--- a/06-fastapi-scrud/app/models.py
+++ b/06-fastapi-scrud/app/models.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, Integer, String, JSON
+from sqlalchemy.ext.declarative import declarative_base
+from pydantic import BaseModel
+from typing import Optional
+
+Base = declarative_base()
+
+
+class Cuisine(Base):
+    __tablename__ = "cuisines"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nom = Column(String, index=True)
+    temps = Column(Integer)
+    ingredients = Column(JSON)
+
+
+class CuisineCreate(BaseModel):
+    nom: str
+    temps: int
+    ingredients: dict
+
+
+class CuisineUpdate(BaseModel):
+    nom: Optional[str] = None
+    temps: Optional[int] = None
+    ingredients: Optional[dict] = None
+
+
+class CuisineRead(BaseModel):
+    id: int
+    nom: str
+    temps: int
+    ingredients: dict
+
+    class Config:
+        orm_mode = True

--- a/06-fastapi-scrud/requirements.txt
+++ b/06-fastapi-scrud/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+sqlalchemy


### PR DESCRIPTION
## Summary
- add Dockerfile, requirements file and .dockerignore for the FastAPI CRUD example
- update README with instructions for building and running the container

## Testing
- `python3 -m py_compile 06-fastapi-scrud/app/main.py 06-fastapi-scrud/app/models.py`


------
https://chatgpt.com/codex/tasks/task_e_685c2f10b318832e81ae669f54fd70a7